### PR TITLE
Added Degree/Radian conversions to TJSpinner.m

### DIFF
--- a/Spinner/TJSpinner.m
+++ b/Spinner/TJSpinner.m
@@ -13,6 +13,16 @@ NSString *const kTJSpinnerTypeActivityIndicator = @"TJActivityIndicator";
 NSString *const kTJSpinnerTypeCircular = @"TJCircularSpinner";
 NSString *const kTJSpinnerTypeBeachBall = @"TJBeachBallSpinner";
 
+//Degree/Radian conversion macros
+#ifndef DEGREES_TO_RADIANS
+#define DEGREES_TO_RADIANS(angle) (angle / 180.0 * M_PI)
+#endif
+
+
+#ifndef RADIANS_TO_DEGREES
+#define RADIANS_TO_DEGREES(radians) ((radians) * (180.0 / M_PI))
+#endif
+
 //Constant for setting beach ball spinner shadow effect
 #define k_SHADOW_OFFSET 0.65
 #define k_CIRCE_EDGE_WIDTH 2.00


### PR DESCRIPTION
So I can use TJSpinner.{h,m} in isolation (and so via CocoaPods), this pull request adds the degree/radian conversions to TJSpinner.m if they haven't already been defined.
